### PR TITLE
Trigger R CMD check with dispatch

### DIFF
--- a/.github/workflows/r-lib-check.yaml
+++ b/.github/workflows/r-lib-check.yaml
@@ -1,6 +1,7 @@
 ---
 name: R-CMD-check (r-lib)
 'on':
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.0.9
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2023-07-21
+Date: 2023-08-29
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
-BoutrosLab.plotting.general 7.0.9 2023-07-21
+BoutrosLab.plotting.general 7.0.9 2023-08-29
 
 UPDATE
-* Run R CMD check GitHub action weekly
+* Run R CMD check GitHub action weekly and with manual dispatch
 
 --------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.0.8 2023-05-26


### PR DESCRIPTION
## Description
Update to allow `R CMD check` to be triggered manually with workflow dispatch.

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.
