### PR TITLE
update barplot documentation for plot.horizontal

### DIFF
--- a/man/create.barplot.Rd
+++ b/man/create.barplot.Rd
@@ -193,7 +193,7 @@ create.barplot(
     \item{col}{Filling colour of bars, defaults to black, does a grey-scale spectrum if !is.null(groups)}
     \item{border.col}{Specify border colour (defaults to black)}
     \item{border.lwd}{Specify border width (defaults to 1)}
-    \item{plot.horizontal}{Plot the bars horizontally.  Note if \code{disable.factor.sorting = TRUE}, then the top row of \code{data} is the bottom row of the plot, i.e. bars are filled in from the bottom to the top of the plot.}
+    \item{plot.horizontal}{Plot the bars horizontally.  Note if \code{disable.factor.sorting = TRUE}, then the top row of \code{data} is the bottom row of the plot, i.e. bars are filled in from the bottom to the top of the plot.  To make the barplot rows match the input data rows, make sure the y-axis variable is a factor, and do \code{data = data[nrow(data):1,]}}
     \item{background.col}{Plot background colour, defaults to transparent}
     \item{origin}{The origin of the plot, generally 0}
     \item{reference}{Should the reference line be printed at the origin}

--- a/man/create.barplot.Rd
+++ b/man/create.barplot.Rd
@@ -193,7 +193,7 @@ create.barplot(
     \item{col}{Filling colour of bars, defaults to black, does a grey-scale spectrum if !is.null(groups)}
     \item{border.col}{Specify border colour (defaults to black)}
     \item{border.lwd}{Specify border width (defaults to 1)}
-    \item{plot.horizontal}{Plot the bars horizontally}
+    \item{plot.horizontal}{Plot the bars horizontally.  Note if \code{disable.factor.sorting = TRUE}, then the top row of \code{data} is the bottom row of the plot, i.e. bars are filled in from the bottom to the top of the plot.}
     \item{background.col}{Plot background colour, defaults to transparent}
     \item{origin}{The origin of the plot, generally 0}
     \item{reference}{Should the reference line be printed at the origin}


### PR DESCRIPTION
## Description

A very common plot we make in the lab is a heatmap with a barplot on the right, using `plot.horizontal = TRUE`. 

For the heatmap, I typically use `same.as.matrix = TRUE` when not clustering, thus I know the order of row/columns of the input data will exactly match the order in the plot.  Then I make sure the barplot data rows are in the same order as the heatmap data rows, and use `disable.factor.sorting = TRUE.`

However, the order of rows in the heatmap and barplot get *misaligned* in this approach, that's because `create.barplot` fills in the bars from the bottom to the top of the plot, although I assumed the opposite (*i.e.* I thought the order of rows in the barplot would match the order of rows in the input data).

Thus I updated the documentation to try and clarify this.

### Closes #... <!-- edit if this PR closes an Issue -->

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [ ] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

see example in comment below
