### PR TITLE
Prep sample order input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 7.1.1
+Version: 7.1.2
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2024-01-08
+Date: 2024-04-02
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+BoutrosLab.plotting.general 7.1.2 2024-04-02
+
+UPDATE
+* Improved "sample.order" argument checking
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.1.1 2024-01-08
 
 UPDATE

--- a/R/create.barplot.R
+++ b/R/create.barplot.R
@@ -617,7 +617,7 @@ create.barplot <- function(
 		}
 
 	# reorder the bars in decreasing or increasing order if specified
-	if (is.null(sample.order) || is.na(sample.order)) { sample.order <- 'none'; }
+	sample.order <- prep.sample.order(sample.order);
 
 	if (sample.order[1] != 'none') {
 		for (i in 1:length(trellis.object$panel.args)) {
@@ -636,7 +636,7 @@ create.barplot <- function(
 					}
 
 				if (length(sample.order) == 1) {
-					if(! sample.order %in% c('decreasing', 'increasing')) {
+					if(!sample.order %in% c('decreasing', 'increasing')) {
 						stop('sample.order should be `decreasing` or `increasing`');
 						}
 

--- a/R/create.barplot.R
+++ b/R/create.barplot.R
@@ -619,7 +619,7 @@ create.barplot <- function(
 	# reorder the bars in decreasing or increasing order if specified
 	sample.order <- prep.sample.order(sample.order);
 
-	if (sample.order[1] != 'none') {
+	if (length(sample.order) != 1 || sample.order != sample.order.default()) {
 		for (i in 1:length(trellis.object$panel.args)) {
 
 			# will need two separate ways for horizontal and non - horizontal
@@ -636,16 +636,11 @@ create.barplot <- function(
 					}
 
 				if (length(sample.order) == 1) {
-					if(!sample.order %in% c('decreasing', 'increasing')) {
-						stop('sample.order should be `decreasing` or `increasing`');
-						}
-
 					# This looks backwards but gets reversed later
 					# Might want to revisit if it makes more sense to sort in correct order here
-					sample.order.decreasing <- sample.order != 'decreasing';
 					ordering <- order(
 						trellis.object$panel.args[[1]]$y[c(1:num.bars)],
-						decreasing = sample.order.decreasing
+						decreasing = sample.order != sample.order.decreasing()
 						);
 					}
 
@@ -699,14 +694,9 @@ create.barplot <- function(
 					}
 
 				if (length(sample.order) == 1) {
-					if(! sample.order %in% c('decreasing', 'increasing')) {
-						stop('sample.order should be `decreasing` or `increasing`');
-						}
-
-					sample.order.decreasing <- sample.order != 'decreasing';
 					ordering <- order(
 						trellis.object$panel.args[[1]]$x[c(1:num.bars)],
-						decreasing = sample.order.decreasing
+						decreasing = sample.order != sample.order.decreasing()
 						);
 					}
 

--- a/R/create.boxplot.R
+++ b/R/create.boxplot.R
@@ -397,8 +397,9 @@ create.boxplot <- function(
 
 		}
 
+    sample.order <- prep.sample.order.setting(sample.order);
 	# reorder by median
-	if (sample.order == 'increasing' | sample.order == 'decreasing') {
+	if (sample.order %in% sample.order.auto.values()) {
 
 		if (is.numeric(trellis.object$panel.args[[1]]$x)) {
 			num.boxes <- levels(trellis.object$panel.args[[1]]$y);
@@ -423,7 +424,9 @@ create.boxplot <- function(
 			ranks <- rank(values.to.sort.by, ties.method = 'random');
 
 			# swap the rankings if decreasing order is specified
-			if (sample.order == 'decreasing') { ranks <- rank(values.to.sort.by * ( -1 ), ties.method = 'random'); }
+			if (sample.order == sample.order.decreasing()) {
+			    ranks <- rank(values.to.sort.by * ( -1 ), ties.method = 'random');
+			    }
 
 			newlocations <- NULL;
 
@@ -476,7 +479,9 @@ create.boxplot <- function(
 
 			ranks <- rank(values.to.sort.by, ties.method = 'random');
 
-			if (sample.order == 'decreasing') { ranks <- rank(values.to.sort.by * (-1), ties.method = 'random'); }
+			if (sample.order == sample.order.decreasing()) {
+			    ranks <- rank(values.to.sort.by * (-1), ties.method = 'random');
+			    }
 
 			newlocations <- NULL;
 

--- a/R/prep.inputs.R
+++ b/R/prep.inputs.R
@@ -1,4 +1,8 @@
 prep.sample.order <- function(sample.order) {
+    if (length((sample.order) == 1)) {
+        return(prep.sample.order.setting(sample.order));
+        }
+
     contains.na <- any(is.na(sample.order));
 
     if (is.null(sample.order) || contains.na) {
@@ -11,5 +15,17 @@ prep.sample.order <- function(sample.order) {
             }
         }
 
+    result <- prep.sample.order;
+    }
+
+prep.sample.order.setting <- function(sample.order) {
+    valid.values <- c(
+        'none',
+        'ascending',
+        'descending'
+    );
+    if (!(sample.order %in% valid.values)) {
+        stop(paste('Invalid "sample.order":', paste0('(', sample.order, ')')))
+        }
     return(sample.order);
     }

--- a/R/prep.inputs.R
+++ b/R/prep.inputs.R
@@ -1,0 +1,15 @@
+prep.sample.order <- function(sample.order) {
+    contains.na <- any(is.na(sample.order));
+
+    if (is.null(sample.order) || contains.na) {
+        sample.order <- 'none';
+
+        if (contains.na) {
+            warning(paste(
+                'NA values found in "sample.order" (using default "none" setting).'
+                ));
+            }
+        }
+
+    return(sample.order);
+    }

--- a/R/prep.inputs.R
+++ b/R/prep.inputs.R
@@ -1,12 +1,12 @@
 prep.sample.order <- function(sample.order) {
-    if (length((sample.order) == 1)) {
+    if (length(sample.order) == 1) {
         return(prep.sample.order.setting(sample.order));
         }
 
     contains.na <- any(is.na(sample.order));
 
     if (is.null(sample.order) || contains.na) {
-        sample.order <- 'none';
+        sample.order <- sample.order.default();
 
         if (contains.na) {
             warning(paste(
@@ -15,17 +15,25 @@ prep.sample.order <- function(sample.order) {
             }
         }
 
-    result <- prep.sample.order;
+    return(sample.order);
     }
 
 prep.sample.order.setting <- function(sample.order) {
-    valid.values <- c(
-        'none',
-        'ascending',
-        'descending'
-    );
-    if (!(sample.order %in% valid.values)) {
+    if (!(sample.order %in% valid.sample.order.values())) {
         stop(paste('Invalid "sample.order":', paste0('(', sample.order, ')')))
         }
     return(sample.order);
+    }
+
+sample.order.default <- function() 'none';
+sample.order.increasing <- function() 'increasing';
+sample.order.decreasing <- function() 'decreasing';
+sample.order.auto.values <- function() {
+    c(sample.order.increasing(), sample.order.decreasing());
+    }
+valid.sample.order.values <- function() {
+    c(
+        sample.order.default(),
+        sample.order.auto.values()
+        );
     }

--- a/tests/testthat/test-prep.inputs.R
+++ b/tests/testthat/test-prep.inputs.R
@@ -1,0 +1,31 @@
+test_that(
+    'prep.sample.order replaces NULL with default',
+    {
+        sample.order <- NULL;
+        result <- prep.sample.order(sample.order);
+
+        expect_equal(result, sample.order.default());
+        }
+    );
+
+test_that(
+    'prep.sample.order replaces with default value if NAs are present',
+    {
+        sample.order <- c(NA, 'sample', 'order', NA);
+        result <- prep.sample.order(sample.order);
+
+        expect_equal(result, sample.order.default());
+        }
+    );
+
+test_that(
+    'prep.sample.order warns if NAs are present',
+    {
+        sample.order <- c(NA, 'sample', 'order', NA);
+        
+        expect_warning(
+            { prep.sample.order(sample.order); },
+            regexp = 'NA'
+            );
+        }
+    );

--- a/tests/testthat/test-prep.inputs.R
+++ b/tests/testthat/test-prep.inputs.R
@@ -29,3 +29,38 @@ test_that(
             );
         }
     );
+
+test_that(
+    'prep.sample.order errors on invalid string input',
+    {
+        sample.order <- 'invalid sample order setting';
+        expect_error(
+            {
+                prep.sample.order(sample.order);
+                },
+            regexp = sample.order
+            );
+        }
+    );
+
+test_that(
+    'prep.sample.order.setting errors with invalid setting',
+    {
+        sample.order <- 'invalid sample order setting';
+        expect_error(
+            {
+                prep.sample.order.setting(sample.order);
+                },
+            regexp = sample.order
+            );
+        }
+    );
+
+test_that(
+    'prep.sample.order.setting returns valid setting',
+    {
+        sample.order <- sample.order.default();
+        result <- prep.sample.order.setting(sample.order);
+        expect_equal(result, sample.order);
+        }
+    );


### PR DESCRIPTION
## Description

Sets up reusable functionality to validate the `sample.order` argument in some plotting functions. Additionally, this refactor allows the functionality to be unit-tested.

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [X] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [X] Both `R CMD build` and `R CMD check` run successfully.
