### PR TITLE
`create.violinplot`: add panel arguments like in `create.scatterplot`

### DIFF
--- a/R/create.violinplot.R
+++ b/R/create.violinplot.R
@@ -25,7 +25,8 @@ create.violinplot <- function(
 	xleft.rectangle = NULL, ybottom.rectangle = NULL, xright.rectangle = NULL, ytop.rectangle = NULL,
 	col.rectangle = 'transparent', alpha.rectangle = 1, height = 6, width = 6, resolution = 1600,
 	size.units = 'in', enable.warnings = FALSE, description = 'Created with BoutrosLab.plotting.general',
-	style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE, disable.factor.sorting = FALSE
+	style = 'BoutrosLab', preload.default = 'custom', use.legacy.settings = FALSE, disable.factor.sorting = FALSE,
+	strip.col = 'white', strip.cex = 1,	strip.fontface = 'bold', layout = NULL
     ) {
 
 	### needed to copy in case using variable to define rectangles dimensions
@@ -303,6 +304,7 @@ create.violinplot <- function(
 					)
 				)
 			),
+		layout = layout,
 		par.settings = list(
 			axis.line = list(
 				lwd = lwd,
@@ -340,6 +342,9 @@ create.violinplot <- function(
 				axis.key.padding = 0.1,
 				right.padding = right.padding
 				),
+			strip.background = list(
+				col = strip.col
+				),
 			box.dot = list(
 				pch = 19,
 				col = '#000000',
@@ -368,6 +373,10 @@ create.violinplot <- function(
 		pch = '|',
 		pretty = TRUE,
 		horizontal = plot.horizontal,
+		par.strip.text = list(
+			cex = strip.cex,
+			fontface = strip.fontface
+			),
 		key = key,
 		legend = legend
 		);

--- a/man/create.violinplot.Rd
+++ b/man/create.violinplot.Rd
@@ -74,7 +74,11 @@ create.violinplot(
 	style = 'BoutrosLab',
 	preload.default = 'custom',
 	use.legacy.settings = FALSE,
-	disable.factor.sorting = FALSE
+	disable.factor.sorting = FALSE,
+	strip.col = 'white',
+	strip.cex = 1,
+	strip.fontface = 'bold',
+	layout = NULL
 	)
 }
 \arguments{
@@ -149,6 +153,10 @@ create.violinplot(
     \item{preload.default}{ability to set multiple sets of diffrent defaults depending on publication needs}
     \item{use.legacy.settings}{boolean to set wheter or not to use legacy mode settings (font)}
     \item{disable.factor.sorting}{Disable barplot auto sorting factors alphabetically/numerically}
+    \item{strip.col}{Strip background colour, defaults to \dQuote{white}}
+    \item{strip.cex}{Size of text in Strip titles}
+    \item{strip.fontface}{Strip title fontface, defaults to bold.  1 = plain, 2 = bold, 3 = italics, 4 = bold and italics}
+    \item{layout}{A vector specifying the number of columns, rows (e.g., c(2,1)).}
 }
 \value{If \code{filename} is \code{NULL} then returns the trellis object, otherwise creates a plot and returns a 0/1 success code.}
 \author{Paul C. Boutros}


### PR DESCRIPTION
## Description

Add panel arguments to `create.violinplot` that are also used in `create.scatterplot, create.boxplot`.  See Tests below for examples.

### Closes #186 

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [ ] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [ ] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

``` r
# To get reprex() to work, need to give root path of BPG to devtools::load_all()
suppressPackageStartupMessages(devtools::load_all('/Users/jarbet/Documents/git/public-R-BoutrosLab-plotting-general'));
#> ℹ Loading BoutrosLab.plotting.general

data(mtcars);
mtcars$am <- factor(
    x = mtcars$am,
    levels = c(1, 0),
    labels = c('yes', 'no')
    );

# default
create.violinplot(
    formula = mpg ~ vs | am,
    data = mtcars
    );
```

![](https://i.imgur.com/aPQmOzK.png)<!-- -->

``` r

# changing the new arguments
create.violinplot(
    formula = mpg ~ vs | am,
    data = mtcars,
    strip.cex = 3,
    strip.fontface = 4,
    layout = c(1,2),
    strip.col = 'lightblue'
    )
```

![](https://i.imgur.com/Xg9oiDB.png)<!-- -->

<sup>Created on 2024-08-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
