### PR TITLE
try replacing unicode to fix R CMD CHECK

### DIFF
--- a/man/create.heatmap.Rd
+++ b/man/create.heatmap.Rd
@@ -832,7 +832,7 @@ create.heatmap(
 # Method 1 of adding symbols (very similar to how text is added)
 points <- microarray[1:20, 1:20][microarray[1:20, 1:20] > 11];
 size.from <- range(points, na.rm = TRUE);
-size.to <- c(1,3);
+size.to <- c(2,6);
 point.size <- (points - size.from[1])/diff(size.from) * diff(size.to) + size.to[1];
 point.colour <- grey(runif(sum(microarray[1:20, 1:20] > 11), max = 0.5));
 
@@ -854,7 +854,7 @@ create.heatmap(
     # flipping rows and columns because the heatmap function does so
     row.pos = which(microarray[1:20, 1:20] > 11, arr.ind = TRUE)[,2],
     col.pos = which(microarray[1:20, 1:20] > 11, arr.ind = TRUE)[,1],
-    cell.text = rep(expression("\u25CF"), times = sum(microarray[1:20, 1:20] > 11)),
+    cell.text = rep('.', times = sum(microarray[1:20, 1:20] > 11)),
     text.col = point.colour,
     text.cex = point.size,
     description = 'Heatmap created using BoutrosLab.plotting.general',


### PR DESCRIPTION
## Description

#188 fails the R CMD CHECK because of a unicode character in a `create.heatmap` example.  Replacing the unicode character fixes the issue.

### Closes #... <!-- edit if this PR closes an Issue -->

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [ ] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

<!-- Include a small working example and a screenshot of the results if applicable. You can use the `reprex` package to automatically generate example code -->

### Case 1

``` r
# input code
```

### Case 2

``` r
# input code
```
