### PR TITLE
CRAN Rcpp dependency fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.1.2
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2024-04-02
+Date: 2024-09-06
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,11 @@
-BoutrosLab.plotting.general 7.1.2 2024-04-02
+
+
+
+BoutrosLab.plotting.general 7.1.2 2024-09-06
 
 UPDATE
 * Improved "sample.order" argument checking
+* Cleaned the C++ namespace by using `R_` versions of Free, Calloc, and Realloc
 
 --------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.1.1 2024-01-08

--- a/src/ks.c
+++ b/src/ks.c
@@ -148,8 +148,8 @@ K(int n, double d)
    k = (int) (n * d) + 1;
    m = 2 * k - 1;
    h = k - n * d;
-   H = (double*) Calloc(m * m, double);
-   Q = (double*) Calloc(m * m, double);
+   H = (double*) R_Calloc(m * m, double);
+   Q = (double*) R_Calloc(m * m, double);
    for(i = 0; i < m; i++)
        for(j = 0; j < m; j++)
 	   if(i - j + 1 < 0)
@@ -177,8 +177,8 @@ K(int n, double d)
        }
    }
    s *= pow(10., eQ);
-   Free(H);
-   Free(Q);
+   R_Free(H);
+   R_Free(Q);
    return(s);
 }
 
@@ -215,7 +215,7 @@ m_power(double *A, int eA, double *V, int *eV, int m, int n)
 	return;
     }
     m_power(A, eA, V, eV, m, n / 2);
-    B = (double*) Calloc(m * m, double);
+    B = (double*) R_Calloc(m * m, double);
     m_multiply(V, V, B, m);
     eB = 2 * (*eV);
     if((n % 2) == 0) {
@@ -232,7 +232,7 @@ m_power(double *A, int eA, double *V, int *eV, int m, int n)
 	    V[i] = V[i] * 1e-140;
 	*eV += 140;
     }
-    Free(B);
+    R_Free(B);
 }
 
 /* Two-sided two-sample */


### PR DESCRIPTION
## Description

This PR addresses time-sensitive CRAN requirements (detailed in #192). `R CMD check` passes locally and on CRAN (including Winbuilder). 

## Winbuilder Results
```
* using log directory 'd:/RCompile/CRANguest/R-devel/BoutrosLab.plotting.general.Rcheck'
* using R Under development (unstable) (2024-09-30 r87204 ucrt)
* using platform: x86_64-w64-mingw32
* R was compiled by
    gcc.exe (GCC) 13.2.0
    GNU Fortran (GCC) 13.2.0
* running under: Windows Server 2022 x64 (build 20348)
* using session charset: UTF-8
* checking for file 'BoutrosLab.plotting.general/DESCRIPTION' ... OK
* checking extension type ... Package
* this is package 'BoutrosLab.plotting.general' version '7.1.2'
* checking CRAN incoming feasibility ... [11s] OK
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking whether package 'BoutrosLab.plotting.general' can be installed ... OK
* used C compiler: 'gcc.exe (GCC) 13.2.0'
* checking installed package size ... OK
* checking package directory ... OK
* checking for future file timestamps ... OK
* checking 'build' directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking code files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking loading without being on the library search path ... OK
* checking use of S3 registration ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... [28s] OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd line widths ... NOTE
Rd file 'create.scatterplot.Rd':
  \examples lines wider than 100 characters:
         # "s" connects points with the vertical segment first. "S" connects points with the horizontal segment first.

These lines will be truncated in the PDF manual.
* checking Rd cross-references ... NOTE
Found the following Rd file(s) with Rd \link{} targets missing package
anchors:
  legend.grob.Rd: draw.key
Please provide package anchors for all Rd \link{} targets not in the
package itself and the base packages.
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking contents of 'data' directory ... OK
* checking data for non-ASCII characters ... OK
* checking LazyData ... OK
* checking data for ASCII and uncompressed saves ... OK
* checking line endings in C/C++/Fortran sources/headers ... OK
* checking pragmas in C/C++ headers and code ... OK
* checking compilation flags used ... OK
* checking compiled code ... OK
* checking sizes of PDF files under 'inst/doc' ... OK
* checking installed files from 'inst/doc' ... OK
* checking files in 'vignettes' ... OK
* checking examples ... [10s] OK
* checking for unstated dependencies in 'tests' ... OK
* checking tests ... OK
  Running 'test_plotting_functions.R'
  Running 'testthat.R'
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes ... OK
* checking re-building of vignette outputs ... [31s] OK
* checking PDF version of manual ... [27s] OK
* checking HTML version of manual ... [14s] OK
* DONE
Status: 2 NOTEs
```

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [x] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

<!-- Include a small working example and a screenshot of the results if applicable. You can use the `reprex` package to automatically generate example code -->

### Case 1

``` r
# input code
```

### Case 2

``` r
# input code
```
