### PR TITLE
Extrapoints orientation in violinplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.1.2
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2024-10-02
+Date: 2025-03-11
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),
@@ -17,7 +17,8 @@ Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@me
              person("Stefan Eng", role = "ctb"),
              person("Mohammed Faizal Eeman Mootor", role = "ctb"),
              person("Rachel Dang", role = "ctb"),
-             person("John Sahrmann", role = "ctb"))
+             person("John Sahrmann", role = "ctb"),
+             person("Yash Patel", role = "ctb"))
 Maintainer: Paul Boutros <PBoutros@mednet.ucla.edu>
 Depends: R (>= 3.5.0), lattice (>= 0.20-35), latticeExtra (>= 0.6-27), cluster (>= 2.0.0), hexbin (>= 1.27.0), grid
 Imports: gridExtra, tools, methods, gtable, e1071, MASS(>= 7.3-29)

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 
 
 
+BoutrosLab.plotting.general 7.1.3 2025-03-11
+
+UPDATE
+* Updated extra points functionality in violin plot to set coordinates based on `plot.horizontal`
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.1.2 2024-09-06
 
 UPDATE

--- a/R/create.violinplot.R
+++ b/R/create.violinplot.R
@@ -214,9 +214,17 @@ create.violinplot <- function(
 
 					for (j in 1:length(extra.points[[i]])) {
 						if (!is.na(extra.points[[i]][j])) {
+							if (plot.horizontal) {
+								xyplot.x <- extra.points[[i]][j];
+								xyplot.y <- j;
+								}
+							else {
+								xyplot.x <- j;
+								xyplot.y <- extra.points[[i]][j];
+								}
 							panel.xyplot(
-								x = j,
-								y = extra.points[[i]][j],
+								x = xyplot.x,
+								y = xyplot.y,
 								pch = extra.points.pch[i],
 								col = if (extra.points.pch[i] %in% 0:20) { extra.points.col[i]; } else if
 									(extra.points.pch[i] %in% 21:25) { extra.points.border[i]; },


### PR DESCRIPTION
## Description

Updating violin plot extra points to set x- and y-coordinate according to `plot.horizontal` option
Diagnosed and tested with @forbiddenpersimmon 

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [ ] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

### Case 1

``` r
create.violinplot(
    formula = variable ~ log10(value),
    data = reads.stats.for.violinplot,
    width = 8,
    height = 18,
    extra.points = list(test.points),
    extra.points.cex = 2,
    yat = reads.stats.axis.formatting$at,
    xlab.label = 'Number of Reads',
    ylab.label = '',
    xaxis.lab = reads.stats.axis.formatting$axis.lab,
    yaxis.lab = c('', as.character(unique(reads.stats.for.violinplot$variable))),
    xaxis.rot = 45,
    yaxis.rot = 0,
    xaxis.tck = 0,
    yaxis.tck = 0,
    legend = list(
        inside = list(
            fun = legend.total.samples,
            x = 0.99,
            y = 0.99,
            corner = c(1,1)
            )
        ),
    top.padding = 4,
    left.padding = 4,
    right.padding = 4,
    file = file.path(args$output_dir, filename.reads.stats),
    resolution = 200,
    plot.horizontal = TRUE
    );
```

<img width="379" alt="image" src="https://github.com/user-attachments/assets/42e8ebb5-9877-41ee-a064-efb6ad8ba871" />

