### PR TITLE
Add new Gleason sum color

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: BoutrosLab.plotting.general
-Version: 7.1.2
+Version: 7.1.3
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2024-10-02
+Date: 2025-03-20
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 
 
+BoutrosLab.plotting.general 7.1.3 2025-03-20
 
+UPDATE
+* Updated gleason sum colour scheme to include a colour for Gleason Sum of 10.
+
+--------------------------------------------------------------------------
 BoutrosLab.plotting.general 7.1.2 2024-09-06
 
 UPDATE

--- a/R/force.colour.scheme.R
+++ b/R/force.colour.scheme.R
@@ -399,7 +399,7 @@ force.colour.scheme <- force.color.scheme <- function(
 			),
 		gleason.sum = list(
 			levels = c(5, 6, 7, 8, 9, 10, 'missing', 'NA'),
-			colours = c('#FEEBE2', '#FBB4B9', '#F768A1', '#C51B8A', '#7A0177', '#4d004b','slategrey', 'slategrey', 'slategrey')
+			colours = c('#FEEBE2', '#FBB4B9', '#F768A1', '#C51B8A', '#7A0177', '#4d004b','slategrey', 'slategrey')
 			),
 		tissue.color = list(
 			levels = c('blood', 'frozen', 'ffpe'),

--- a/R/force.colour.scheme.R
+++ b/R/force.colour.scheme.R
@@ -291,7 +291,7 @@ force.colour.scheme <- force.color.scheme <- function(
 	mt.annotation.6 <- '#A00000';
 	mt.annotation.7 <- '#FFFF78';
 	mt.annotation.8 <- 'white';
-	
+
 	#ISUP Grade
 	isup.grade.1 <- 'cornsilk';
         isup.grade.2 <- 'yellow';
@@ -398,8 +398,8 @@ force.colour.scheme <- force.color.scheme <- function(
 			colours = c('white', 'yellow', 'orange', 'red', 'brown', 'maroon3', 'magenta4', 'mediumblue', 'black', 'slategrey', 'slategrey')
 			),
 		gleason.sum = list(
-			levels = c(5, 6, 7, 8, 9, 'missing', 'NA'),
-			colours = c('#FEEBE2', '#FBB4B9', '#F768A1', '#C51B8A', '#7A0177', 'slategrey', 'slategrey', 'slategrey')
+			levels = c(5, 6, 7, 8, 9, 10, 'missing', 'NA'),
+			colours = c('#FEEBE2', '#FBB4B9', '#F768A1', '#C51B8A', '#7A0177', '#4d004b','slategrey', 'slategrey', 'slategrey')
 			),
 		tissue.color = list(
 			levels = c('blood', 'frozen', 'ffpe'),


### PR DESCRIPTION
## Description

Adds a new color for Gleason Sum of 10 and removes extra grey that is mistakenly in the colour scheme

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [x] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [ ] Both `R CMD build` and `R CMD check` run successfully.

