### PR TITLE
Optional V8 dev dependency for HTML vignette

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,5 +32,6 @@ jobs:
           sudo apt-get install -y \
             libjpeg-dev \
             libpng-dev \
-            libcairo2-dev
+            libcairo2-dev \
+            Install V8 OS dependency in CI/CD workflow
       - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,5 +33,6 @@ jobs:
             libjpeg-dev \
             libpng-dev \
             libcairo2-dev \
-            libv8-dev
+            libv8-dev \
+            libcurl4-openssl-dev
       - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,5 +33,5 @@ jobs:
             libjpeg-dev \
             libpng-dev \
             libcairo2-dev \
-            Install V8 OS dependency in CI/CD workflow
+            libv8-dev
       - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports: gridExtra, tools, methods, gtable, e1071, MASS(>= 7.3-29)
 Suggests:
     Cairo (>= 1.5-1),
     knitr,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    V8
 Description: Contains several plotting functions such as barplots, scatterplots, heatmaps, as well as functions to combine plots and assist in the creation of these plots. These functions will give users great ease of use and customization options in broad use for biomedical applications, as well as general purpose plotting. Each of the functions also provides valid default settings to make plotting data more efficient and producing high quality plots with standard colour schemes simpler. All functions within this package are capable of producing plots that are of the quality to be presented in scientific publications and journals. P'ng et al.; BPG: Seamless, automated and interactive visualization of scientific data; BMC Bioinformatics 2019 <doi:10.1186/s12859-019-2610-2>.
 License: GPL-2
 URL: https://github.com/uclahs-cds/package-BoutrosLab-plotting-general


### PR DESCRIPTION
## Description
Addresses the following false-positive `R CMD check` note:

> `Skipping checking math rendering: package 'V8' unavailable`

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [X] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [X] Both `R CMD build` and `R CMD check` run successfully.