### PR TITLE
Fix GHA unicode error and always return plot

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,5 +33,6 @@ jobs:
             libjpeg-dev \
             libpng-dev \
             libcairo2-dev \
-            fonts-dejavu-core
+            fonts-dejavu-core \
+            r-cran-ragg
       - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,5 +32,6 @@ jobs:
           sudo apt-get install -y \
             libjpeg-dev \
             libpng-dev \
-            libcairo2-dev
+            libcairo2-dev \
+            fonts-dejavu-core
       - uses: uclahs-cds/tool-R-CMD-check-action@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: BoutrosLab.plotting.general
 Version: 7.1.4
 Type: Package
 Title: Functions to Create Publication-Quality Plots
-Date: 2025-06-19
+Date: 2025-06-21
 Authors@R: c(person("Paul Boutros", role = c("aut", "cre"), email = "PBoutros@mednet.ucla.edu"),
              person("Christine P'ng", role = "ctb"),
              person("Jeff Green", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# BoutrosLab.plotting.general 7.1.4 (2025-06-19)
+# BoutrosLab.plotting.general 7.1.4 (2025-06-21)
 
 ## Fixed
 - Updated extra points functionality in violin plot to properly set coordinates based on `plot.horizontal`
@@ -6,6 +6,9 @@
 ## Added
 - `create.violinplot` panel and x-axis arguments
 - Parameterize `title.y.coord` in `legend.grob()`
+
+## Changed
+- Always return the lattice plot object regardless of whether a file is exported
 
 # BoutrosLab.plotting.general 7.1.3 (2025-06-13)
 

--- a/R/write.plot.R
+++ b/R/write.plot.R
@@ -224,9 +224,6 @@ write.plot <- function(
 					}
 				}
 			}
-		else {
-			return(trellis.object);
-			}
 		}
 
 	# check if graphics device is postscript
@@ -238,4 +235,6 @@ write.plot <- function(
 	if (enable.warnings && 1 == dev.cur()) {
 		warning('\nIf you wish to print this plot to postscript device, please set family param as: postscript(family=\"sans\").\n');
 		}
-	}
+
+    return(trellis.object);
+    }


### PR DESCRIPTION
## Description

<!--- Briefly describe the changes included in this pull request  --->

### Closes #... <!-- edit if this PR closes an Issue -->

## Checklist

<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

-   [ ] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data. A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).

-   [ ] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files. To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.

-   [ ] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

-   [ ] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

-   [ ] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

-   [ ] I have added the major changes included in this pull request to the `NEWS` under the next release version or unreleased, and updated the date. I have also updated the version number in `DESCRIPTION` according to [semantic versioning](https://semver.org/) rules.

-   [ ] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

<!-- Include a small working example and a screenshot of the results if applicable. You can use the `reprex` package to automatically generate example code -->

### Case 1

``` r
# input code
```

### Case 2

``` r
# input code
```
